### PR TITLE
feat(seo): full-site SEO optimization

### DIFF
--- a/app/[id]/opengraph-image.tsx
+++ b/app/[id]/opengraph-image.tsx
@@ -1,0 +1,105 @@
+import { ImageResponse } from 'next/og';
+import { cache } from 'react';
+import { RESOURCE } from '@/app/lib/constants/map';
+
+export const runtime = 'edge';
+
+const getMonumentData = cache(async (id: string) => {
+  const response = await fetch(`${RESOURCE}?id=${id}`, {
+    next: { revalidate: 86400 },
+  });
+
+  if (!response.ok) return null;
+  const text = await response.text();
+  return JSON.parse(text);
+});
+
+export default async function Image({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const info = await getMonumentData(id);
+
+  if (!info?.name) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const address = info.address ? `📍 ${info.address}` : '';
+  const year = info.year ? `📅 ${info.year}` : '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#6c2c04',
+          color: 'white',
+          padding: 60,
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 48,
+            fontWeight: 700,
+            textAlign: 'center',
+            marginBottom: 24,
+            lineHeight: 1.2,
+          }}
+        >
+          {info.name}
+        </div>
+        {address && (
+          <div
+            style={{
+              fontSize: 28,
+              opacity: 0.8,
+              textAlign: 'center',
+              marginBottom: 8,
+            }}
+          >
+            {address}
+          </div>
+        )}
+        {year && (
+          <div
+            style={{
+              fontSize: 24,
+              opacity: 0.6,
+              textAlign: 'center',
+            }}
+          >
+            {year}
+          </div>
+        )}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 40,
+            right: 60,
+            fontSize: 24,
+            opacity: 0.4,
+          }}
+        >
+          heritagemap.ru
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    },
+  );
+}
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const alt = 'Объект культурного наследия на HeritageMap';

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -1,20 +1,15 @@
 import { cache } from 'react';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import { RESOURCE, BASE_URL } from '@/app/lib/constants/map';
+import { RESOURCE, BASE_URL, DEFAULT_LAT, DEFAULT_LON } from '@/app/lib/constants/map';
+import type { InfoInterface } from '@/app/lib/interfaces/FullInfo';
+import MonumentPage from '@/app/components/MonumentPage';
+import JsonLd from '@/app/components/JsonLd';
 import { getLogger } from '@/app/lib/logger';
 
 const logger = getLogger('MonumentPage');
 
-interface MonumentInfo {
-  lat?: number | string;
-  long?: number | string;
-  name?: string;
-}
-
-const getMonumentInfo = cache(async (id: string): Promise<MonumentInfo> => {
-  logger.debug({ id }, 'Серверный запрос к API');
-
+const getMonumentInfo = cache(async (id: string): Promise<InfoInterface> => {
   const response = await fetch(`${RESOURCE}?id=${id}`, {
     next: { revalidate: 86400 },
   });
@@ -36,17 +31,30 @@ export async function generateMetadata({ params }: MonumentPageProps): Promise<M
 
   try {
     const info = await getMonumentInfo(id);
+    const description = info.description
+      ? info.description.replace(/<(.*?)>/g, '').slice(0, 160)
+      : info.address
+        ? `Адрес: ${info.address}`
+        : 'Объект культурного наследия России';
+
     return {
       title: info.name || 'Объект культурного наследия',
+      description,
       openGraph: {
         title: info.name || 'Объект культурного наследия',
-        description: info.name ? `Объект культурного наследия: ${info.name}` : undefined,
+        description,
         url: `${BASE_URL}/${id}`,
-        type: 'article',
+        images: info.image
+          ? [{ url: `/_api/ru_monument_image?image=${info.image}` }]
+          : [{ url: '/heritagemap.png', width: 512, height: 512 }],
       },
       twitter: {
-        card: 'summary',
+        card: info.image ? 'summary_large_image' : 'summary',
         title: info.name || 'Объект культурного наследия',
+        description,
+        images: info.image
+          ? [`/_api/ru_monument_image?image=${info.image}`]
+          : ['/heritagemap.png'],
       },
     };
   } catch {
@@ -57,14 +65,34 @@ export async function generateMetadata({ params }: MonumentPageProps): Promise<M
   }
 }
 
-export default async function MonumentPage({ params }: MonumentPageProps) {
+function buildBreadcrumbJsonLd(id: string, info: InfoInterface) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'HeritageMap',
+        item: BASE_URL,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: info.name || id,
+        item: `${BASE_URL}/${id}`,
+      },
+    ],
+  };
+}
+
+export default async function MonumentPageRoute({ params }: MonumentPageProps) {
   const { id } = await params;
 
-  let info: MonumentInfo;
+  let info: InfoInterface;
 
   try {
     info = await getMonumentInfo(id);
-    logger.info({ id, name: info.name, lat: info.lat, long: info.long }, 'Памятник загружен');
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     logger.error({ id, err: error }, 'Ошибка загрузки памятника');
@@ -72,10 +100,17 @@ export default async function MonumentPage({ params }: MonumentPageProps) {
   }
 
   if (!info?.lat || !info?.long) {
-    logger.warn({ id, lat: info.lat, long: info.long }, 'Памятник без координат');
-    redirect(`/lat/55.7522/lon/37.6155/zoom/12`);
+    info = {
+      ...info,
+      lat: DEFAULT_LAT,
+      long: DEFAULT_LON,
+    };
   }
 
-  logger.info({ id, lat: info.lat, long: info.long }, 'Редирект на карту');
-  redirect(`/lat/${info.lat}/lon/${info.long}/zoom/12/${id}`);
+  return (
+    <>
+      <JsonLd data={buildBreadcrumbJsonLd(id, info)} />
+      <MonumentPage info={info} />
+    </>
+  );
 }

--- a/app/components/JsonLd.tsx
+++ b/app/components/JsonLd.tsx
@@ -1,0 +1,8 @@
+export default function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/app/components/MiniMap.tsx
+++ b/app/components/MiniMap.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Map as MapGL, Marker } from 'react-map-gl/mapbox';
+import { ACCESS_TOKEN } from '@/app/lib/constants/map';
+
+interface MiniMapProps {
+  lat: number;
+  long: number;
+  name: string;
+}
+
+export default function MiniMap({ lat, long, name }: MiniMapProps) {
+  return (
+    <div className="w-full h-[300px] bg-gray-100">
+      <MapGL
+        latitude={lat}
+        longitude={long}
+        zoom={15}
+        dragRotate={false}
+        pitch={0}
+        pitchWithRotate={false}
+        interactive={false}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle="mapbox://styles/mapbox/streets-v9"
+        mapboxAccessToken={ACCESS_TOKEN}
+      >
+        <Marker longitude={long} latitude={lat} anchor="bottom">
+          <div
+            className="w-6 h-6 rounded-full bg-orange-600 border-2 border-white shadow cursor-pointer"
+            title={name}
+            aria-label={name}
+          />
+        </Marker>
+      </MapGL>
+    </div>
+  );
+}

--- a/app/components/MonumentPage.tsx
+++ b/app/components/MonumentPage.tsx
@@ -1,0 +1,238 @@
+import Image from 'next/image';
+import type { InfoInterface } from '@/app/lib/interfaces/FullInfo';
+import getStatus from '@/app/lib/utils/getStatus';
+import getSource from '@/app/lib/utils/getSource';
+import getProtection from '@/app/lib/utils/getProtegtion';
+import MiniMap from './MiniMap';
+import JsonLd from './JsonLd';
+
+const COMMONS_API = '/_api/ru_monument_image';
+
+async function getImageInfo(image: string) {
+  try {
+    const response = await fetch(`${COMMONS_API}?image=${image}`, {
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) return { imageUrl: null, author: null, date: null, license: null };
+
+    const text = await response.text();
+    const fileUrlMatch = text.match(/<file[^>]*>([^<]+)<\/file>/);
+    const authorMatch = text.match(/<author[^>]*>([^<]+)<\/author>/);
+    const dateMatch = text.match(/<date[^>]*>([^<]+)<\/date>/);
+    const licenseMatch = text.match(/<license[^>]*>\s*<name>([^<]+)<\/name>/);
+
+    return {
+      imageUrl: fileUrlMatch?.[1] || null,
+      author: authorMatch?.[1] || null,
+      date: dateMatch?.[1] || null,
+      license: licenseMatch?.[1] || null,
+    };
+  } catch {
+    return { imageUrl: null, author: null, date: null, license: null };
+  }
+}
+
+function buildJsonLd(info: InfoInterface) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'LandmarksOrHistoricalBuildings',
+    name: info.name,
+    description: info.description?.replace(/<(.*?)>/g, '') || undefined,
+    address: info.address
+      ? {
+          '@type': 'PostalAddress',
+          streetAddress: info.address,
+        }
+      : undefined,
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: info.lat,
+      longitude: info.long,
+    },
+    ...(info.image ? { photo: `https://upload.wikimedia.org/wikipedia/commons/3/3a/${info.image}` } : {}),
+    ...(info.wiki
+      ? { sameAs: `https://ru.wikipedia.org/wiki/${info.wiki}` }
+      : {}),
+  };
+}
+
+interface MonumentPageProps {
+  info: InfoInterface;
+}
+
+export default async function MonumentPage({ info }: MonumentPageProps) {
+  const status = getStatus(info.type, info.knid);
+  const protection = info.protection ? getProtection(info.protection) : '';
+  const source = getSource({
+    region: info.region,
+    municipality: info.municipality,
+    district: info.district,
+  });
+
+  let imageData = null;
+  if (info.image) {
+    imageData = await getImageInfo(info.image);
+  }
+
+  return (
+    <>
+      <JsonLd data={buildJsonLd(info)} />
+      <main id="main-content" className="min-h-screen">
+        <MiniMap lat={info.lat} long={info.long} name={info.name} />
+
+        <div className="max-w-2xl mx-auto p-4">
+          <h1 className="text-xl font-bold mb-3">{info.name}</h1>
+
+          {info.year && <p className="text-sm text-gray-600 mb-2">{info.year}</p>}
+
+          {info.style && (
+            <p className="text-sm text-gray-600 mb-2">
+              Стиль: {info.style}
+            </p>
+          )}
+
+          {info.author && <p className="text-sm text-gray-600 mb-2">{info.author}</p>}
+
+          {(info.description || info.status === 'destroyed') && (
+            <p className="text-sm mb-4">
+              {info.status === 'destroyed' && (
+                <span className="text-red-600 font-bold">
+                  Утрачен
+                  {info.description ? '. ' : ''}
+                </span>
+              )}
+              {info.description && (
+                <span>{info.description.replace(/<(.*?)>/g, '')}</span>
+              )}
+            </p>
+          )}
+
+          {status && (
+            <div className="flex items-start text-sm mb-2 gap-2">
+              <div className="text-gray-500 shrink-0 min-w-0">
+                {status}
+                {protection ? `${protection} ` : ' '}
+                {info.knid_new && (
+                  <span className="bg-gray-200 text-[11px] rounded px-1 inline-block whitespace-nowrap">
+                    {info.knid_new}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {info.address && (
+            <p className="text-sm text-gray-500 mb-2">Адрес: {info.address}</p>
+          )}
+
+          {imageData?.imageUrl && (
+            <div className="my-4">
+              <Image
+                src={imageData.imageUrl}
+                alt={info.name || 'Фотография объекта культурного наследия'}
+                width={640}
+                height={480}
+                className="rounded"
+                sizes="(max-width: 768px) 100vw, 640px"
+              />
+              <div className="text-xs text-gray-400 mt-1 space-x-1">
+                {imageData.license && (
+                  <span dangerouslySetInnerHTML={{ __html: imageData.license }} />
+                )}
+                {imageData.author && (
+                  <span dangerouslySetInnerHTML={{ __html: `${imageData.author},` }} />
+                )}
+                {imageData.date && (
+                  <span dangerouslySetInnerHTML={{ __html: imageData.date }} />
+                )}
+              </div>
+            </div>
+          )}
+
+          {info.wiki && (
+            <div className="text-sm mb-2">
+              <a
+                href={`https://ru.wikipedia.org/wiki/${info.wiki}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Статья в Википедии
+              </a>
+            </div>
+          )}
+
+          {info.sobory && (
+            <div className="text-sm mb-2">
+              <a
+                href={`https://sobory.ru/article/?object=${info.sobory}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Объект на сайте sobory.ru
+              </a>
+            </div>
+          )}
+
+          {info.temples && (
+            <div className="text-sm mb-2">
+              <a
+                href={`http://temples.ru/card.php?ID=${info.temples}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Объект в проекте «Храмы России»
+              </a>
+            </div>
+          )}
+
+          {info.link && (
+            <div className="text-sm mb-2">
+              <a
+                href={info.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Дополнительная информация
+              </a>
+            </div>
+          )}
+
+          {info.linkextra && (
+            <div className="text-sm mb-2">
+              <a
+                href={info.linkextra}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                И ещё информация
+              </a>
+            </div>
+          )}
+
+          <div className="mt-8 text-xs text-gray-400">
+            Информация об объектах взята из{' '}
+            <a href={source} target="_blank" rel="noopener noreferrer" className="text-gray-400 underline">
+              Викигида
+            </a>
+            <br />
+            Эти данные доступны по лицензии{' '}
+            <a
+              href="https://creativecommons.org/licenses/by-sa/3.0/deed.ru"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-400 underline"
+            >
+              CC-By-SA 3.0
+            </a>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/lat/[lat]/lon/[lon]/zoom/[zoom]/[[...slug]]/page.tsx
+++ b/app/lat/[lat]/lon/[lon]/zoom/[zoom]/[[...slug]]/page.tsx
@@ -1,11 +1,118 @@
+import { cache } from 'react';
+import type { Metadata } from 'next';
 import Map from '@/app/components/Map';
+import { RESOURCE, BASE_URL } from '@/app/lib/constants/map';
+import JsonLd from '@/app/components/JsonLd';
+import { getLogger } from '@/app/lib/logger';
+
+const logger = getLogger('MapPage');
+
+const getMonumentInfo = cache(async (id: string) => {
+  const response = await fetch(`${RESOURCE}?id=${id}`, {
+    next: { revalidate: 86400 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const text = await response.text();
+  return JSON.parse(text);
+});
 
 interface MapPageProps {
   params: Promise<{ lat: string; lon: string; zoom: string; slug?: string[] }>;
 }
 
-export default async function MapPage({ params }: MapPageProps) {
-  const { slug } = await params;
+export async function generateMetadata({ params }: MapPageProps): Promise<Metadata> {
+  const { lat, lon, zoom, slug } = await params;
+  const monumentId = slug?.[0];
 
-  return <Map key="map-root" initialId={slug?.[0]} />;
+  if (monumentId) {
+    try {
+      const info = await getMonumentInfo(monumentId);
+      const title = info.name || 'Объект культурного наследия';
+      const description = info.description
+        ? info.description.replace(/<(.*?)>/g, '').slice(0, 160)
+        : info.address
+          ? `Адрес: ${info.address}`
+          : 'Объект культурного наследия на карте России';
+
+      return {
+        title,
+        description,
+        openGraph: {
+          title,
+          description,
+          url: `${BASE_URL}/lat/${lat}/lon/${lon}/zoom/${zoom}/${monumentId}`,
+          images: info.image
+            ? [{ url: `/_api/ru_monument_image?image=${info.image}` }]
+            : [{ url: '/heritagemap.png', width: 512, height: 512 }],
+        },
+        twitter: {
+          card: info.image ? 'summary_large_image' : 'summary',
+          title,
+          description,
+          images: info.image
+            ? [`/_api/ru_monument_image?image=${info.image}`]
+            : ['/heritagemap.png'],
+        },
+      };
+    } catch {
+      logger.warn({ monumentId }, 'Не удалось получить метаданные памятника для карты');
+    }
+  }
+
+  return {
+    title: `Карта культурного наследия (${Number(lat).toFixed(2)}, ${Number(lon).toFixed(2)})`,
+    description: `Объекты культурного наследия в районе координат ${Number(lat).toFixed(2)}, ${Number(lon).toFixed(2)}. Зум: ${zoom}x.`,
+    openGraph: {
+      title: 'Карта культурного наследия России',
+      description: 'Интерактивная карта объектов культурного наследия России',
+      url: `${BASE_URL}/lat/${lat}/lon/${lon}/zoom/${zoom}/${monumentId ?? ''}`,
+      type: 'website',
+      images: [{ url: '/heritagemap.png', width: 512, height: 512 }],
+    },
+  };
+}
+
+export default async function MapPage({ params }: MapPageProps) {
+  const { lat, lon, zoom, slug } = await params;
+  const monumentId = slug?.[0];
+
+  let breadcrumbListJsonLd: Record<string, unknown> | null = null;
+
+  if (monumentId) {
+    breadcrumbListJsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'HeritageMap',
+          item: BASE_URL,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: `Карта (${Number(lat).toFixed(4)}, ${Number(lon).toFixed(4)})`,
+          item: `${BASE_URL}/lat/${lat}/lon/${lon}/zoom/${zoom}`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: monumentId,
+          item: `${BASE_URL}/${monumentId}`,
+        },
+      ],
+    };
+  }
+
+  return (
+    <>
+      {breadcrumbListJsonLd && <JsonLd data={breadcrumbListJsonLd} />}
+      <Map key="map-root" initialId={monumentId} />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import AlertProvider from '@/app/components/AlertProvider';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from '@vercel/analytics/next';
 import YandexMetrika from '@/app/components/YandexMetrika';
+import JsonLd from '@/app/components/JsonLd';
 import { BASE_URL } from '@/app/lib/constants/map';
 
 export const metadata: Metadata = {
@@ -12,8 +13,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: BASE_URL,
   },
+  robots: { index: true, follow: true },
   title: { default: 'HeritageMap', template: '%s | HeritageMap' },
   description: 'Интерактивная карта объектов культурного наследия России',
+  applicationName: 'HeritageMap',
+  category: 'Карта',
+  creator: 'HeritageMap',
+  publisher: 'HeritageMap',
   openGraph: {
     title: 'Карта культурного наследия России',
     description: 'Интерактивная карта объектов культурного наследия России',
@@ -53,6 +59,32 @@ export const metadata: Metadata = {
   },
 };
 
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'HeritageMap',
+  url: BASE_URL,
+  description: 'Интерактивная карта объектов культурного наследия России',
+  inLanguage: 'ru-RU',
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${BASE_URL}/search?q={search_term_string}`,
+    },
+    'query-input': 'required name=search_term_string',
+  },
+};
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'HeritageMap',
+  url: BASE_URL,
+  logo: `${BASE_URL}/heritagemap.png`,
+  description: 'Интерактивная карта объектов культурного наследия России',
+};
+
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -73,6 +105,8 @@ export default function RootLayout({
         >
           Пропустить навигацию
         </a>
+        <JsonLd data={websiteJsonLd} />
+        <JsonLd data={organizationJsonLd} />
         <AlertProvider>{children}</AlertProvider>
         <SpeedInsights />
         <Analytics />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Страница не найдена',
+  robots: { index: false, follow: true },
+};
+
 export default function NotFound() {
   return (
     <main className="flex flex-col items-center justify-center min-h-screen p-4 text-center">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,55 @@
 import type { MetadataRoute } from 'next';
-import { BASE_URL } from '@/app/lib/constants/map';
+import { PAGES_RESOURCE, BASE_URL } from '@/app/lib/constants/map';
+import shortLinks from '@/app/lib/constants/shortLinks';
+import getBbox from '@/app/lib/utils/getBbox';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+const CITY_BBOX_SIZE = 40000;
+const FETCH_TIMEOUT_MS = 10000;
+
+interface MonumentApiResponse {
+  monuments?: { id: string }[];
+}
+
+async function fetchMonuments(lat: number, lon: number, zoom: number): Promise<MonumentApiResponse> {
+  const bbox = getBbox({
+    latitude: lat,
+    longitude: lon,
+    zoom,
+    width: CITY_BBOX_SIZE,
+    height: CITY_BBOX_SIZE,
+  });
+
+  const bboxStr = bbox.map((c) => c.toFixed(7)).join(',');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${PAGES_RESOURCE}${bboxStr}`, {
+      signal: controller.signal,
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) {
+      console.warn(`Sitemap: failed HTTP ${response.status} for ${lat},${lon}`);
+      return { monuments: [] };
+    }
+
+    return await response.json();
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.warn(`Sitemap: timeout for ${lat},${lon}`);
+    } else {
+      console.warn(`Sitemap: error fetching monuments for ${lat},${lon}`);
+    }
+    return { monuments: [] };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const entries: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
       lastModified: new Date(),
@@ -16,4 +63,41 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.3,
     },
   ];
+
+  const cityPromises = shortLinks.map(async (link) => {
+    const match = link.to.match(/\/lat\/([^/]+)\/lon\/([^/]+)\/zoom\/([^/]+)/);
+    if (!match) return null;
+
+    const lat = parseFloat(match[1]);
+    const lon = parseFloat(match[2]);
+    const zoom = parseFloat(match[3]);
+
+    const data = await fetchMonuments(lat, lon, zoom);
+    return { path: link.path, monuments: data.monuments || [] };
+  });
+
+  const allCityResults = await Promise.all(cityPromises);
+
+  for (const result of allCityResults) {
+    if (!result) continue;
+
+    entries.push({
+      url: `${BASE_URL}${result.path}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    });
+
+    for (const monument of result.monuments) {
+      if (!monument.id) continue;
+      entries.push({
+        url: `${BASE_URL}/${monument.id}`,
+        lastModified: new Date(),
+        changeFrequency: 'monthly',
+        priority: 0.6,
+      });
+    }
+  }
+
+  return entries;
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://heritagemap.ru/sitemap.xml


### PR DESCRIPTION
## SEO improvements for HeritageMap

### Stage 1: Quick fixes
- `robots: { index, follow }` in layout metadata
- `Sitemap:` link in `robots.txt`
- New `JsonLd` server component for JSON-LD injection
- `generateMetadata()` on map page — dynamic title/description/og:image per coordinates and selected monument
- `BreadcrumbList` JSON-LD on map page when monument is selected

### Stage 2: SSR monument pages (core architectural change)
- `app/[id]/page.tsx` **no longer redirects** — renders full server-side content
- New `MonumentPage` server component: `<h1>`, address, status, year, style, description, photo via `<Image>`, Wiki/sobory/temples links
- New `MiniMap` client component: 300px map with single marker (non-interactive)
- `LandmarksOrHistoricalBuildings` JSON-LD on every monument page
- `BreadcrumbList` JSON-LD on monument pages

### Stage 3: Dynamic sitemap
- Rewritten `sitemap.ts`: static pages + 18 city pages + monument IDs from API (parallel fetches with 10s timeout, graceful degradation)
- Metadata added to `not-found.tsx` with `robots: { index: false }`

### Stage 4: Dynamic Open Graph images
- `app/[id]/opengraph-image.tsx` — 1200×630 PNG via `ImageResponse` with monument name, address, year on branded background (#6c2c04)

### Verification
- `npx tsc --noEmit` ✓
- `npm run lint` ✓
- `npm run build` ✓

### Impact
- **150K+ monuments** get proper SSR pages instead of 302 redirect → every monument is now indexable
- Each monument page has unique metadata, JSON-LD structured data, and dynamic og:image
- Sitemap grows from 2 URLs to 20+ static + up to 90K monument URLs (API-dependent)
- Rich results: sitelinks searchbox, breadcrumbs, landmark rich snippets