### PR TITLE
ci(e2e): separate playwright install-deps from browser install to fix CI hang

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+
       - name: Install Playwright browsers
         run: npx playwright install chromium
 


### PR DESCRIPTION
## What

Fix 6-hour CI timeout in the E2E workflow.

## Root cause

`npx playwright install chromium` on GitHub Actions runners downloads the browser successfully, then hangs indefinitely while trying to install system dependencies via `apt-get` (likely due to apt lock contention).

## Fix

Split Playwright installation into two steps:
1. `npx playwright install-deps chromium` — installs system dependencies first
2. `npx playwright install chromium` — downloads browser binary only

This makes failures visible at the specific failing step and prevents multi-hour hangs.